### PR TITLE
feat - tests + evals

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -58,6 +58,15 @@ or use in Cursor
 
 ## Development
 
+
+
+## Running evals
+
+The evals package loads an mcp client that then runs the index.ts file, so there is no need to rebuild between tests. You can load environment variables by prefixing the npx command. Full documentation can be found [here](https://www.mcpevals.io/docs).
+
+```bash
+OPENAI_API_KEY=your-key  npx mcp-eval src/evals/evals.ts src/utils/toolRegister.ts
+```
 ```bash
 # git clone 
 git clone https://github.com/AdsPower/local-api-mcp-typescript.git

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "@modelcontextprotocol/sdk": "^1.7.0",
     "axios": "^1.8.4",
     "playwright": "^1.51.1",
-    "zod": "^3.24.2"
+    "zod": "^3.24.2",
+    "mcp-evals": "^1.0.18"
   },
   "devDependencies": {
     "@types/node": "^22.13.13",

--- a/src/evals/evals.ts
+++ b/src/evals/evals.ts
@@ -1,0 +1,59 @@
+//evals.ts
+
+import { EvalConfig } from 'mcp-evals';
+import { openai } from "@ai-sdk/openai";
+import { grade, EvalFunction } from "mcp-evals";
+
+const openBrowserEval: EvalFunction = {
+    name: 'open-browser Tool Evaluation',
+    description: 'Evaluates the open-browser tool functionality',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Open the browser with an environment of 'staging' and a profile of 'user-profile' to visit https://example.com");
+        return JSON.parse(result);
+    }
+};
+
+const closeBrowserEval: EvalFunction = {
+    name: 'close-browser Evaluation',
+    description: 'Evaluates the close-browser tool functionality',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please close my current browser session and confirm it's done.");
+        return JSON.parse(result);
+    }
+};
+
+const createBrowserEval: EvalFunction = {
+  name: "Create Browser Tool Evaluation",
+  description: "Evaluates the creation of a browser instance",
+  run: async () => {
+    const result = await grade(openai("gpt-4"), "Please create a new browser instance and confirm it is ready for further actions.");
+    return JSON.parse(result);
+  }
+};
+
+const updateBrowserEval: EvalFunction = {
+    name: 'update-browser',
+    description: 'Tests the update-browser tool by prompting a browser update request',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please update my browser to the latest version.");
+        return JSON.parse(result);
+    }
+};
+
+const deleteBrowserEval: EvalFunction = {
+    name: 'Delete Browser Tool Evaluation',
+    description: 'Evaluates the functionality of the delete browser tool',
+    run: async () => {
+        const result = await grade(openai("gpt-4"), "Please delete the browser completely. Can you remove it from memory?");
+        return JSON.parse(result);
+    }
+};
+
+const config: EvalConfig = {
+    model: openai("gpt-4"),
+    evals: [openBrowserEval, closeBrowserEval, createBrowserEval, updateBrowserEval, deleteBrowserEval]
+};
+  
+export default config;
+  
+export const evals = [openBrowserEval, closeBrowserEval, createBrowserEval, updateBrowserEval, deleteBrowserEval];


### PR DESCRIPTION
Adds new e2e test that loads an MCP client, which in turn runs the server and processes the actual tool call. Afterwards, it then grades the response for correctness. 

note: I'm the package author 