### PR TITLE
Add OpenClaw MCP configuration to README

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -56,6 +56,11 @@ Codex:
 codex mcp add --env PORT="50325" --env API_KEY="your_api_key" adspower-local-api -- npx -y local-api-mcp-typescript
 ```
 
+OpenClaw:
+```bash
+openclaw mcp set adspower-local-api '{"command":"npx","args":["-y","local-api-mcp-typescript"],"env":{"PORT":"50325","API_KEY":"your_api_key"}}'
+```
+
 Cursor: Go to Cursor Settings -> MCP -> Add New MCP Server, and then paste the following content:
 ```json
 {


### PR DESCRIPTION
Hi,

I have added the configuration command for OpenClaw using the Model Context Protocol (MCP) to the README.md file.
This helps users quickly integrate the AdsPower Local API with OpenClaw by running a single command.

Openclaw MCP:
bash
,,,
openclaw mcp set adspower-local-api '{"command":"npx","args":["-y","local-api-mcp-typescript"],"env":{"PORT":"50325","API_KEY":"your_api_key"}}'
,,,

Please review and merge this change if it looks good. Thanks!