### PR TITLE
新增 Shell Tab 补全、Schema 参数帮助与交互式错误恢复

### DIFF
--- a/packages/adspower-browser/README.MD
+++ b/packages/adspower-browser/README.MD
@@ -65,7 +65,7 @@ ads start
 
 The CLI supports prefix tab completion for subcommands and common flags (`-k`, `-p`, etc.) via [`@bomb.sh/tab`](https://bomb.sh/docs/tab/). Enable it once in your shell:
 
-**zsh**
+**macOS — zsh**
 
 ```bash
 ads complete zsh > ~/.ads-completion.zsh
@@ -73,7 +73,7 @@ echo 'source ~/.ads-completion.zsh' >> ~/.zshrc
 source ~/.ads-completion.zsh
 ```
 
-**bash**
+**Linux — bash**
 
 ```bash
 ads complete bash > ~/.ads-completion.bash
@@ -81,7 +81,34 @@ echo 'source ~/.ads-completion.bash' >> ~/.bashrc
 source ~/.ads-completion.bash
 ```
 
-After setup, `ads`, `adspower`, and `adspower-browser` share the same completions:
+On Linux login shells, ensure `~/.bashrc` is sourced (e.g. from `~/.bash_profile`).
+
+**Linux — zsh**
+
+```bash
+ads complete zsh > ~/.ads-completion.zsh
+echo 'source ~/.ads-completion.zsh' >> ~/.zshrc
+source ~/.ads-completion.zsh
+```
+
+**Windows — PowerShell**
+
+```powershell
+ads complete powershell > $HOME\.ads-completion.ps1
+if (-not (Test-Path $PROFILE)) { New-Item -Path $PROFILE -ItemType File -Force }
+Add-Content $PROFILE '. $HOME\.ads-completion.ps1'
+. $HOME\.ads-completion.ps1
+```
+
+**Windows — Git Bash**
+
+```bash
+ads complete bash > ~/.ads-completion.bash
+echo 'source ~/.ads-completion.bash' >> ~/.bashrc
+source ~/.ads-completion.bash
+```
+
+After setup on zsh/bash, `ads`, `adspower`, and `adspower-browser` share the same completions. On PowerShell and Git Bash, use `ads` for tab completion:
 
 ```bash
 ads <Tab><Tab>      # list subcommands

--- a/packages/adspower-browser/README.MD
+++ b/packages/adspower-browser/README.MD
@@ -61,6 +61,34 @@ ads start
    - `ads open-browser '{"profile_id":"abc123","launch_args":"..."}'`
    - Commands with no params: omit `<arg>` or use `'{}'`.
 
+## Shell Tab Completion
+
+The CLI supports prefix tab completion for subcommands and common flags (`-k`, `-p`, etc.) via [`@bomb.sh/tab`](https://bomb.sh/docs/tab/). Enable it once in your shell:
+
+**zsh**
+
+```bash
+ads complete zsh > ~/.ads-completion.zsh
+echo 'source ~/.ads-completion.zsh' >> ~/.zshrc
+source ~/.ads-completion.zsh
+```
+
+**bash**
+
+```bash
+ads complete bash > ~/.ads-completion.bash
+echo 'source ~/.ads-completion.bash' >> ~/.bashrc
+source ~/.ads-completion.bash
+```
+
+After setup, `ads`, `adspower`, and `adspower-browser` share the same completions:
+
+```bash
+ads <Tab><Tab>      # list subcommands
+ads open-<Tab>      # complete to open-browser
+ads sta<Tab>        # complete to start / status
+```
+
 ## Essential Commands With CLI
 
 You can use `ads -h` or `ads <command> -h` to view the specific parameters.

--- a/packages/adspower-browser/package.json
+++ b/packages/adspower-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adspower-browser",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "main": "cli/index.js",
   "type": "commonjs",
   "bin": {
@@ -13,12 +13,13 @@
     "adspower": "node cli/index.js"
   },
   "dependencies": {
+    "@bomb.sh/tab": "^0.0.15",
     "axios": "^1.8.4",
     "colors": "^1.4.0",
     "commander": "^14.0.3",
     "fs-extra2": "^1.0.1",
     "playwright-core": "^1.51.1",
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adspower/local-api-core": "workspace:*",

--- a/packages/adspower-browser/package.json
+++ b/packages/adspower-browser/package.json
@@ -1,6 +1,6 @@
 {
   "name": "adspower-browser",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "main": "cli/index.js",
   "type": "commonjs",
   "bin": {

--- a/packages/adspower-browser/src/cli.ts
+++ b/packages/adspower-browser/src/cli.ts
@@ -8,12 +8,71 @@ import {
     patchHandlers,
     buildCliCommandDescription
 } from '@adspower/local-api-core';
+import { schemas } from '@adspower/local-api-core/src/types/schemas';
 
-type HandlerFn = (params: any) => Promise<string | unknown>;
+export type HandlerFn = (params: any) => Promise<string | unknown>;
 
-type Handler = {
+export type Handler = {
     fn: HandlerFn;
     description: string;
+    paramsDescription: string;
+}
+
+function formatJsonValueForHelp(value: unknown, indent: number): string {
+    const pad = '  '.repeat(indent);
+    const childPad = '  '.repeat(indent + 1);
+
+    if (value === null || typeof value !== 'object') {
+        return JSON.stringify(value);
+    }
+
+    if (Array.isArray(value)) {
+        if (value.length === 0) {
+            return '[]';
+        }
+
+        const lines = value.map((item) => `${childPad}${formatJsonValueForHelp(item, indent + 1)}`);
+        return `[\n${lines.join(',\n')}\n${pad}]`;
+    }
+
+    const entries = Object.entries(value as Record<string, unknown>);
+    if (entries.length === 0) {
+        return '{}';
+    }
+
+    const lines = entries.map(([key, val]) => {
+        if (['enum', 'oneOf', 'required'].includes(key) && Array.isArray(val)) {
+            return `${childPad}${JSON.stringify(key)}: ${JSON.stringify(val)}`;
+        }
+
+        return `${childPad}${JSON.stringify(key)}: ${formatJsonValueForHelp(val, indent + 1)}`;
+    });
+
+    return `{\n${lines.join(',\n')}\n${pad}}`;
+}
+
+export function formatSchemaPropertiesForHelp(properties: unknown): string {
+    return formatJsonValueForHelp(properties, 0);
+}
+
+function schemaParamsDescription(schema: { toJSONSchema(): { properties?: unknown } }, type: string): string {
+    let paramStr = 'view help: https://documenter.getpostman.com/view/45822952/2sB2x5JDXn\n';
+    switch (type) {
+        case 'open-browser':
+            paramStr += 'use cmd: "ads open-browser <profile_id>"\nor use params: "ads open-browser \'{"profile_id":"..."}\' "\n';
+            break;
+        case 'close-browser':
+            paramStr += 'use cmd: "ads close-browser <profile_id>"\nor use params: "ads close-browser \'{"profile_id":"..."}\' "\n';
+            break;
+        case 'get-profile-cookies':
+            paramStr += 'use cmd: "ads get-profile-cookies <profile_id>"\nor use params: "ads get-profile-cookies \'{"profile_id":"..."}\' "\n';
+            break;
+        case 'get-browser-active':
+            paramStr += 'use cmd: "ads get-browser-active <profile_id>"\nor use params: "ads get-browser-active \'{"profile_id":"..."}\' "\n';
+            break;
+    }
+    const _str = formatSchemaPropertiesForHelp(schema.toJSONSchema().properties);
+    return paramStr + _str;
 }
 
 export const STATELESS_HANDLERS: Record<string, Handler> = {
@@ -22,161 +81,193 @@ export const STATELESS_HANDLERS: Record<string, Handler> = {
         description: buildCliCommandDescription(
             'open-browser',
             'Open the browser, both environment and profile mean browser'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.openBrowserSchema, 'open-browser')
     },
     'close-browser': {
         fn: browserHandlers.closeBrowser as HandlerFn,
-        description: buildCliCommandDescription('close-browser', 'Close the browser')
+        description: buildCliCommandDescription('close-browser', 'Close the browser'),
+        paramsDescription: schemaParamsDescription(schemas.closeBrowserSchema, 'close-browser')
     },
     'create-browser': {
         fn: browserHandlers.createBrowser as HandlerFn,
-        description: buildCliCommandDescription('create-browser', 'Create a browser')
+        description: buildCliCommandDescription('create-browser', 'Create a browser'),
+        paramsDescription: schemaParamsDescription(schemas.createBrowserSchema, 'create-browser')
     },
     'update-browser': {
         fn: browserHandlers.updateBrowser as HandlerFn,
-        description: buildCliCommandDescription('update-browser', 'Update the browser')
+        description: buildCliCommandDescription('update-browser', 'Update the browser'),
+        paramsDescription: schemaParamsDescription(schemas.updateBrowserSchema, 'update-browser')
     },
     'delete-browser': {
         fn: browserHandlers.deleteBrowser as HandlerFn,
-        description: buildCliCommandDescription('delete-browser', 'Delete the browser')
+        description: buildCliCommandDescription('delete-browser', 'Delete the browser'),
+        paramsDescription: schemaParamsDescription(schemas.deleteBrowserSchema, 'delete-browser')
     },
     'get-browser-list': {
         fn: browserHandlers.getBrowserList as HandlerFn,
-        description: buildCliCommandDescription('get-browser-list', 'Get the list of browsers')
+        description: buildCliCommandDescription('get-browser-list', 'Get the list of browsers'),
+        paramsDescription: schemaParamsDescription(schemas.getBrowserListSchema, 'get-browser-list')
     },
     'get-opened-browser': {
         fn: browserHandlers.getOpenedBrowser as HandlerFn,
-        description: buildCliCommandDescription('get-opened-browser', 'Get the list of opened browsers')
+        description: buildCliCommandDescription('get-opened-browser', 'Get the list of opened browsers'),
+        paramsDescription: schemaParamsDescription(schemas.emptySchema, 'get-opened-browser')
     },
     'move-browser': {
         fn: browserHandlers.moveBrowser as HandlerFn,
-        description: buildCliCommandDescription('move-browser', 'Move browsers to a group')
+        description: buildCliCommandDescription('move-browser', 'Move browsers to a group'),
+        paramsDescription: schemaParamsDescription(schemas.moveBrowserSchema, 'move-browser')
     },
     'get-profile-cookies': {
         fn: browserHandlers.getProfileCookies as HandlerFn,
         description: buildCliCommandDescription(
             'get-profile-cookies',
             'Query and return cookies of the specified profile. Only one profile can be queried per request.'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.getProfileCookiesSchema, 'get-profile-cookies')
     },
     'get-profile-ua': {
         fn: browserHandlers.getProfileUa as HandlerFn,
         description: buildCliCommandDescription(
             'get-profile-ua',
             'Query and return the User-Agent of specified profiles. Up to 10 profiles can be queried per request.'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.getProfileUaSchema, 'get-profile-ua')
     },
     'close-all-profiles': {
         fn: browserHandlers.closeAllProfiles as HandlerFn,
         description: buildCliCommandDescription(
             'close-all-profiles',
             'Close all opened profiles on the current device'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.closeAllProfilesSchema, 'close-all-profiles')
     },
     'new-fingerprint': {
         fn: browserHandlers.newFingerprint as HandlerFn,
         description: buildCliCommandDescription(
             'new-fingerprint',
             'Generate a new fingerprint for specified profiles. Up to 10 profiles are supported per request.'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.newFingerprintSchema, 'new-fingerprint')
     },
     'delete-cache-v2': {
         fn: browserHandlers.deleteCacheV2 as HandlerFn,
         description: buildCliCommandDescription(
             'delete-cache-v2',
             'Clear local cache of specific profiles.For account security, please ensure that there are no open browsers on the device when using this interface.'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.deleteCacheV2Schema, 'delete-cache-v2')
     },
     'share-profile': {
         fn: browserHandlers.shareProfile as HandlerFn,
         description: buildCliCommandDescription(
             'share-profile',
             'Share profiles via account email or phone number. The maximum number of profiles that can be shared at one time is 200.'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.shareProfileSchema, 'share-profile')
     },
     'get-browser-active': {
         fn: browserHandlers.getBrowserActive as HandlerFn,
-        description: buildCliCommandDescription('get-browser-active', 'Get active browser profile information')
+        description: buildCliCommandDescription('get-browser-active', 'Get active browser profile information'),
+        paramsDescription: schemaParamsDescription(schemas.getBrowserActiveSchema, 'get-browser-active')
     },
     'get-cloud-active': {
         fn: browserHandlers.getCloudActive as HandlerFn,
         description: buildCliCommandDescription(
             'get-cloud-active',
             'Query the status of browser profiles by user_ids, up to 100 profiles per request. If the team has enabled "Multi device mode," specific statuses cannot be retrieved and the response will indicate "Profile not opened."'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.getCloudActiveSchema, 'get-cloud-active')
     },
     'create-group': {
         fn: groupHandlers.createGroup as HandlerFn,
-        description: buildCliCommandDescription('create-group', 'Create a browser group')
+        description: buildCliCommandDescription('create-group', 'Create a browser group'),
+        paramsDescription: schemaParamsDescription(schemas.createGroupSchema, 'create-group')
     },
     'update-group': {
         fn: groupHandlers.updateGroup as HandlerFn,
-        description: buildCliCommandDescription('update-group', 'Update the browser group')
+        description: buildCliCommandDescription('update-group', 'Update the browser group'),
+        paramsDescription: schemaParamsDescription(schemas.updateGroupSchema, 'update-group')
     },
     'get-group-list': {
         fn: groupHandlers.getGroupList as HandlerFn,
-        description: buildCliCommandDescription('get-group-list', 'Get the list of groups')
+        description: buildCliCommandDescription('get-group-list', 'Get the list of groups'),
+        paramsDescription: schemaParamsDescription(schemas.getGroupListSchema, 'get-group-list')
     },
     'check-status': {
         fn: applicationHandlers.checkStatus as HandlerFn,
         description: buildCliCommandDescription(
             'check-status',
             'Check the availability of the current device API interface (Connection Status)'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.emptySchema, 'check-status')
     },
     'get-application-list': {
         fn: applicationHandlers.getApplicationList as HandlerFn,
         description: buildCliCommandDescription(
             'get-application-list',
             'Get the list of applications (categories)'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.getApplicationListSchema, 'get-application-list')
     },
     'create-proxy': {
         fn: proxyHandlers.createProxy as HandlerFn,
-        description: buildCliCommandDescription('create-proxy', 'Create the proxy')
+        description: buildCliCommandDescription('create-proxy', 'Create the proxy'),
+        paramsDescription: schemaParamsDescription(schemas.createProxySchema, 'create-proxy')
     },
     'update-proxy': {
         fn: proxyHandlers.updateProxy as HandlerFn,
-        description: buildCliCommandDescription('update-proxy', 'Update the proxy')
+        description: buildCliCommandDescription('update-proxy', 'Update the proxy'),
+        paramsDescription: schemaParamsDescription(schemas.updateProxySchema, 'update-proxy')
     },
     'get-proxy-list': {
         fn: proxyHandlers.getProxyList as HandlerFn,
-        description: buildCliCommandDescription('get-proxy-list', 'Get the list of proxies')
+        description: buildCliCommandDescription('get-proxy-list', 'Get the list of proxies'),
+        paramsDescription: schemaParamsDescription(schemas.getProxyListSchema, 'get-proxy-list')
     },
     'delete-proxy': {
         fn: proxyHandlers.deleteProxy as HandlerFn,
-        description: buildCliCommandDescription('delete-proxy', 'Delete the proxy')
+        description: buildCliCommandDescription('delete-proxy', 'Delete the proxy'),
+        paramsDescription: schemaParamsDescription(schemas.deleteProxySchema, 'delete-proxy')
     },
     'get-tag-list': {
         fn: tagHandlers.getTagList as HandlerFn,
-        description: buildCliCommandDescription('get-tag-list', 'Get the list of browser tags')
+        description: buildCliCommandDescription('get-tag-list', 'Get the list of browser tags'),
+        paramsDescription: schemaParamsDescription(schemas.getTagListSchema, 'get-tag-list')
     },
     'create-tag': {
         fn: tagHandlers.createTag as HandlerFn,
-        description: buildCliCommandDescription('create-tag', 'Create browser tags (batch supported)')
+        description: buildCliCommandDescription('create-tag', 'Create browser tags (batch supported)'),
+        paramsDescription: schemaParamsDescription(schemas.createTagSchema, 'create-tag')
     },
     'update-tag': {
         fn: tagHandlers.updateTag as HandlerFn,
-        description: buildCliCommandDescription('update-tag', 'Update browser tags (batch supported)')
+        description: buildCliCommandDescription('update-tag', 'Update browser tags (batch supported)'),
+        paramsDescription: schemaParamsDescription(schemas.updateTagSchema, 'update-tag')
     },
     'delete-tag': {
         fn: tagHandlers.deleteTag as HandlerFn,
-        description: buildCliCommandDescription('delete-tag', 'Delete browser tags')
+        description: buildCliCommandDescription('delete-tag', 'Delete browser tags'),
+        paramsDescription: schemaParamsDescription(schemas.deleteTagSchema, 'delete-tag')
     },
     'download-kernel': {
         fn: kernelHandlers.downloadKernel as HandlerFn,
         description: buildCliCommandDescription(
             'download-kernel',
             'Download or update a browser kernel version'
-        )
+        ),
+        paramsDescription: schemaParamsDescription(schemas.downloadKernelSchema, 'download-kernel')
     },
     'get-kernel-list': {
         fn: kernelHandlers.getKernelList as HandlerFn,
-        description: buildCliCommandDescription('get-kernel-list', 'Get browser kernel list by type or all')
+        description: buildCliCommandDescription('get-kernel-list', 'Get browser kernel list by type or all'),
+        paramsDescription: schemaParamsDescription(schemas.getKernelListSchema, 'get-kernel-list')
     },
     'update-patch': {
         fn: patchHandlers.updatePatch as HandlerFn,
-        description: buildCliCommandDescription('update-patch', 'Update AdsPower to latest patch version')
+        description: buildCliCommandDescription('update-patch', 'Update AdsPower to latest patch version'),
+        paramsDescription: schemaParamsDescription(schemas.updatePatchSchema, 'update-patch')
     },
 };
 

--- a/packages/adspower-browser/src/completion.ts
+++ b/packages/adspower-browser/src/completion.ts
@@ -1,0 +1,61 @@
+import tab from '@bomb.sh/tab/commander';
+import type { Command } from 'commander';
+
+const CLI_BIN_ALIASES = ['ads', 'adspower', 'adspower-browser'] as const;
+
+export function patchShellCompletionScript(shell: string, script: string): string {
+    if (shell === 'zsh') {
+        return script
+            .replace(/^#compdef .+$/m, `#compdef ${CLI_BIN_ALIASES.join(' ')}`)
+            .replace(/^compdef _ads ads$/m, `compdef _ads ${CLI_BIN_ALIASES.join(' ')}`);
+    }
+
+    if (shell === 'bash') {
+        return script.replace(
+            /^complete -F __ads_complete ads$/m,
+            `complete -F __ads_complete ${CLI_BIN_ALIASES.join(' ')}`
+        );
+    }
+
+    return script;
+}
+
+export function setupShellCompletion(program: Command): void {
+    program.name('ads');
+    tab(program);
+}
+
+export function isShellCompletionRequest(argv: string[] = process.argv): boolean {
+    const completionIndex = argv.indexOf('complete');
+    const dashDashIndex = argv.indexOf('--');
+    return completionIndex !== -1 && dashDashIndex !== -1 && dashDashIndex > completionIndex;
+}
+
+export function wrapShellScriptOutput(shell: string | undefined): () => void {
+    if (shell !== 'zsh' && shell !== 'bash') {
+        return () => {};
+    }
+
+    const originalWrite = process.stdout.write.bind(process.stdout);
+
+    process.stdout.write = ((chunk, encoding?, callback?) => {
+        const text = typeof chunk === 'string'
+            ? chunk
+            : Buffer.from(chunk).toString(typeof encoding === 'string' ? encoding : 'utf8');
+        const patched = patchShellCompletionScript(shell, text);
+
+        if (typeof encoding === 'function') {
+            return originalWrite(patched, encoding);
+        }
+
+        return originalWrite(
+            patched,
+            encoding as BufferEncoding | undefined,
+            callback as ((err?: Error | null) => void) | undefined
+        );
+    }) as typeof process.stdout.write;
+
+    return () => {
+        process.stdout.write = originalWrite;
+    };
+}

--- a/packages/adspower-browser/src/core/start.ts
+++ b/packages/adspower-browser/src/core/start.ts
@@ -1,10 +1,22 @@
+import * as fs from 'node:fs';
 import * as path from 'node:path';
-import { ChildProcess, exec, fork } from 'node:child_process';
+import { ChildProcess, fork } from 'node:child_process';
 import { store } from '../store';
 import { browsersKill, ensureBrowserPath, initSqlite3, isRunning, logError, logInfo, logSuccess, logWarning, readPidFile, removePidFile, sleepTime, toTerminalLink, writePidFile } from '../tools';
 
 type ForkOptionsWithWindowsHide = Parameters<typeof fork>[2] & {
     windowsHide?: boolean;
+};
+
+const getRuntimeExecArgv = (): string[] => {
+    if (process.platform !== 'win32') {
+        return [];
+    }
+    const preload = path.join(__dirname, 'core/winHideChildProcess.js');
+    if (!fs.existsSync(preload)) {
+        return [];
+    }
+    return ['--require', preload];
 };
 
 const getEnv = (): Record<string, string | boolean | undefined> => {
@@ -44,7 +56,8 @@ export const startChild = (type?: string) => {
                 env,
                 detached: true,
                 windowsHide: true, // 隐藏子进程的控制台窗口
-                stdio: ['ignore', 'ignore', 'ignore', 'ipc']
+                stdio: ['ignore', 'ignore', 'ignore', 'ipc'],
+                execArgv: getRuntimeExecArgv(),
             };
             child = fork(mainJs, [], forkOptions);
             ensureBrowserPath();

--- a/packages/adspower-browser/src/core/winHideChildProcess.js
+++ b/packages/adspower-browser/src/core/winHideChildProcess.js
@@ -1,0 +1,59 @@
+'use strict';
+
+/**
+ * Preload for the forked AdsPower runtime (main.min.js) on Windows.
+ * Patches child_process before main.min.js loads so exec/spawn calls
+ * (wmic, tasklist, reg query, etc.) do not flash visible cmd.exe windows.
+ */
+if (process.platform !== 'win32') {
+    return;
+}
+
+const cp = require('node:child_process');
+
+function withWindowsHide(options) {
+    if (typeof options === 'object' && options !== null && !Array.isArray(options)) {
+        if (options.windowsHide === false) {
+            return options;
+        }
+        return { ...options, windowsHide: true };
+    }
+    return { windowsHide: true };
+}
+
+function normalizeExecArgs(options, callback) {
+    if (typeof options === 'function') {
+        return { options: { windowsHide: true }, callback: options };
+    }
+    return { options: withWindowsHide(options || {}), callback };
+}
+
+function normalizeSpawnArgs(args, options) {
+    if (Array.isArray(args)) {
+        return { args, options: withWindowsHide(options || {}) };
+    }
+    return { args: [], options: withWindowsHide(args || {}) };
+}
+
+const origExec = cp.exec.bind(cp);
+cp.exec = function exec(cmd, options, callback) {
+    const { options: opts, callback: cb } = normalizeExecArgs(options, callback);
+    return origExec(cmd, opts, cb);
+};
+
+const origExecSync = cp.execSync.bind(cp);
+cp.execSync = function execSync(cmd, options) {
+    return origExecSync(cmd, withWindowsHide(options || {}));
+};
+
+const origSpawn = cp.spawn.bind(cp);
+cp.spawn = function spawn(command, args, options) {
+    const normalized = normalizeSpawnArgs(args, options);
+    return origSpawn(command, normalized.args, normalized.options);
+};
+
+const origSpawnSync = cp.spawnSync.bind(cp);
+cp.spawnSync = function spawnSync(command, args, options) {
+    const normalized = normalizeSpawnArgs(args, options);
+    return origSpawnSync(command, normalized.args, normalized.options);
+};

--- a/packages/adspower-browser/src/handleAction.ts
+++ b/packages/adspower-browser/src/handleAction.ts
@@ -141,10 +141,9 @@ const handleError = async (msg: string, commandName: string, params: any) => {
                     STATELESS_HANDLERS['get-opened-browser'].fn
                 );
                 if (result) {
-                    const jsonStr = result.replace(/^Opened browser list:\s*/, '');
                     try {
-                        const list = JSON.parse(jsonStr) as Array<{ user_id: string }>;
-                        const userIds = list.map((item) => item.user_id);
+                        const data: any = JSON.parse(result);
+                        const userIds = data.list.map((item: any) => item.user_id);
                         if (userIds.length === 1) {
                             // 如果只有一个已经打开的环境，则询问是否要帮他直接关闭
                             const answer = await promptYesNo(`[?] Only one opened profile. Close it now?`);
@@ -163,7 +162,7 @@ const handleError = async (msg: string, commandName: string, params: any) => {
                             logWarning(`[!] If you want to close all profiles, please enter "ads close-all-profiles"`);
                         }
                     } catch (error) {
-                        
+                        console.error(error);
                     }
                 }
             }

--- a/packages/adspower-browser/src/handleAction.ts
+++ b/packages/adspower-browser/src/handleAction.ts
@@ -1,0 +1,199 @@
+import * as readline from 'node:readline/promises';
+import { updateConfig } from "@adspower/local-api-core";
+import { green } from "colors";
+import { HandlerFn, resolveStatelessCommandArgs, STATELESS_HANDLERS } from "./cli";
+import { restartChild } from "./core/start";
+import { hasRunning, logError, getApiKeyAndPort, logSuccess, createLoading, logInfo, sleepTime, logWarning } from "./tools";
+
+const renderKernelProgress = (result: any) => {
+    const status = result.status || 'pending';
+    const progress = ['completed', 'installing'].includes(status) ? 100 : Math.max(0, Math.min(100, Number(result.progress) || 0));
+
+    if (!process.stdout.isTTY) {
+        logInfo(`Kernel progress: ${progress}% [${status}]`);
+        return;
+    }
+
+    const width = 30;
+    const filled = Math.round((progress / 100) * width);
+    const bar = `${'='.repeat(filled)}${'-'.repeat(width - filled)}`;
+    process.stdout.write(`\r[${bar}] ${progress.toFixed(0).padStart(3, ' ')}% ${status}     `);
+};
+
+const finishKernelProgress = () => {
+    if (process.stdout.isTTY) {
+        process.stdout.write('\n');
+    }
+};
+
+const trackKernelDownload = async (fnc: HandlerFn, args: Record<string, any>) => {
+    while (true) {
+        const result = await fnc(args);
+        try {
+            const resultJson: any = JSON.parse((result as string));
+            if (resultJson && resultJson.status && ['pending', 'downloading', 'completed', 'installing', 'failed'].includes(resultJson.status)) {
+                renderKernelProgress(resultJson);
+                if (['completed', 'failed'].includes(resultJson.status)) {
+                    finishKernelProgress();
+                    return result;
+                }
+                await sleepTime(3000);
+            } else {
+                return result;
+            }
+        } catch (error) {
+            return result;
+        }
+    }
+};
+
+export const handleAction = async (params: any, options: any, command: any, fnc: HandlerFn) => {
+    const isRun = await hasRunning(options);
+    if (!isRun) {
+        logError('[!] Adspower runtime is not running');
+        const info = `[i] Please run "${green("adspower-browser start -k <apiKey>")}" to start the adspower runtime`;
+        console.log(info);
+        return;
+    }
+    const { apiKey, port } = getApiKeyAndPort(options);
+    updateConfig(apiKey, port);
+
+    const commandName = command.name();
+    // Preserve the external Local API contract names before handing params to the core handlers.
+    const resolved = resolveStatelessCommandArgs(commandName, params);
+    if (!resolved.ok) {
+        logError(resolved.error);
+        return;
+    }
+    const args = resolved.args;
+    logSuccess(`Executing command: ${commandName}, params: ${JSON.stringify(args)}`);
+    const loading = createLoading(`Executing ${commandName}...`);
+    try {
+        if (commandName === 'download-kernel') {
+            loading.stop();
+            const result = await trackKernelDownload(fnc, args);
+            const out = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+            logInfo(`\n\n${out}\n\n`);
+        } else {
+            const result = await fnc(args);
+            const out = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
+            loading.stop();
+            logInfo(`\n\n${out}\n`);
+            if (commandName === 'update-patch' && !out.includes('The client is already on the latest patch version. No update is required')) {
+                await sleepTime(1000 * 60);
+                await restartChild();
+            }
+            return out;
+        }
+    } catch (error) {
+        loading.stop();
+        const msg = error instanceof Error ? error.message : JSON.stringify(error);
+        logError(`\n${msg}\n`);
+        await handleError(msg, commandName, params);
+    } finally {
+        loading.stop();
+    }
+};
+
+const handleError = async (msg: string, commandName: string, params: any) => {
+    if (commandName === 'open-browser') {
+        if (msg.includes('ready,please to download!')) {
+            const reg = /(SunBrowser|FlowerBrowser) (\d+) is not ready,please to download!/;
+            const match = msg.match(reg);
+            if (match) {
+                const kernelType = match[1] === 'FlowerBrowser' ? 'Firefox' : 'Chrome';
+                const kernelVersion = match[2];
+                if (kernelType && kernelVersion) {
+                    //问答模式的命令执行，询问用户是否需要下载内核，用户输入 y 或 n 后，执行 download-kernel 命令
+                    const answer = await promptYesNo(`[?] Kernel ${match[1]} ${kernelVersion} is not ready. Download now?`);
+                    if (answer === 'y') {
+                        // 我想要直接执行 ads download-kernel {"kernel_type":"Chrome","kernel_version":"141"} 这个命令
+                        const _params = {"kernel_type":kernelType,"kernel_version":kernelVersion};
+                        await handleAction(
+                            JSON.stringify(_params), 
+                            {}, 
+                            {name: () => 'download-kernel'}, 
+                            STATELESS_HANDLERS['download-kernel'].fn
+                        );
+                        await sleepTime(1000 * 3);
+                        // 再次执行 open-browser 命令
+                        await handleAction(
+                            params,
+                            {}, 
+                            {name: () => 'open-browser'}, 
+                            STATELESS_HANDLERS['open-browser'].fn
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    if (commandName === 'close-browser') {
+        if (msg.includes('Profile does not exist')) {
+            // 如果发现关闭的profile不存在，则询问用户是否需要帮他查出来所有已经打开的环境
+            const answer = await promptYesNo(`[?] Profile does not exist. Check all opened profiles?`);
+            if (answer === 'y') {
+                const result = await handleAction(
+                    '{}',
+                    {},
+                    {name: () => 'get-opened-browser'},
+                    STATELESS_HANDLERS['get-opened-browser'].fn
+                );
+                if (result) {
+                    const jsonStr = result.replace(/^Opened browser list:\s*/, '');
+                    try {
+                        const list = JSON.parse(jsonStr) as Array<{ user_id: string }>;
+                        const userIds = list.map((item) => item.user_id);
+                        if (userIds.length === 1) {
+                            // 如果只有一个已经打开的环境，则询问是否要帮他直接关闭
+                            const answer = await promptYesNo(`[?] Only one opened profile. Close it now?`);
+                            if (answer === 'y') {
+                                await handleAction(
+                                    `{"profile_id":["${userIds[0]}"]}`,
+                                    {},
+                                    {name: () => 'close-browser'},
+                                    STATELESS_HANDLERS['close-browser'].fn
+                                );
+                            }
+                        } else if (userIds.length > 1) {
+                            // 如果是多个浏览器的话，就直接输入可以关闭的浏览器id
+                            logWarning(`[!] Closeable profiles: ${userIds.join(', ')}`);
+                            // 如果你要关闭所有的浏览器,可以使用 "ads close-all-profiles" 这个命令
+                            logWarning(`[!] If you want to close all profiles, please enter "ads close-all-profiles"`);
+                        }
+                    } catch (error) {
+                        
+                    }
+                }
+            }
+        }
+    }
+};
+
+export async function promptYesNo(question: string): Promise<'y' | 'n' | null> {
+    if (!process.stdin.isTTY || !process.stdout.isTTY) {
+        logWarning('[!] Interactive prompt is unavailable in non-interactive mode.');
+        return null;
+    }
+
+    const rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+    });
+
+    try {
+        while (true) {
+            const answer = (await rl.question(`${question} [y/N]: `)).trim().toLowerCase();
+            if (answer === 'y' || answer === 'yes') {
+                return 'y';
+            }
+            if (answer === 'n' || answer === 'no' || answer === '') {
+                return 'n';
+            }
+            logWarning('[!] Please enter y or n.');
+        }
+    } finally {
+        rl.close();
+    }
+}

--- a/packages/adspower-browser/src/index.ts
+++ b/packages/adspower-browser/src/index.ts
@@ -2,14 +2,14 @@
 import { Command, Option } from "commander";
 import { store } from "./store";
 import { getChildStatus, restartChild, startChild, stopChild } from "./core/start";
-import { createLoading, getApiKeyAndPort, hasRunning, logError, logInfo, logSuccess, sleepTime, trackKernelDownload, VERSION } from "./tools";
-import { green } from 'colors';
-import { updateConfig } from '@adspower/local-api-core';
-import { resolveStatelessCommandArgs, STATELESS_HANDLERS } from "./cli";
+import { logError, VERSION } from "./tools";
+import { STATELESS_HANDLERS } from "./cli";
 import { resolveStartApiKey } from "./startConfig";
+import { isShellCompletionRequest, setupShellCompletion, wrapShellScriptOutput } from "./completion";
+import { handleAction } from "./handleAction";
 
 const program = new Command();
-program.name("adspower-browser").description("CLI and runtime for adspower-browser").version(VERSION);
+program.description("CLI and runtime for adspower-browser").version(VERSION);
 
 // 设置API Key
 program.command("start")
@@ -53,52 +53,27 @@ program.command("status")
 
 for (const cmd of Object.keys(STATELESS_HANDLERS)) {
     const fnc = STATELESS_HANDLERS[cmd].fn;
-    program.command(`${cmd} [params]`)
+    program.command(`${cmd}`)
         .description(STATELESS_HANDLERS[cmd].description)
         .option("-k, --api-key <apiKey>", "Set the API key for the adspower runtime")
         .option("-p, --port <port>", "Set the port for the adspower runtime")
+        .argument("[params]", STATELESS_HANDLERS[cmd].paramsDescription)
         .action(async (params, options, command) => {
-            const isRun = await hasRunning(options);
-            if (!isRun) {
-                logError('[!] Adspower runtime is not running');
-                const info = `[i] Please run "${green("adspower-browser start -k <apiKey>")}" to start the adspower runtime`;
-                console.log(info);
-                return;
-            }
-            const { apiKey, port } = getApiKeyAndPort(options);
-            updateConfig(apiKey, port);
-            // Preserve the external Local API contract names before handing params to the core handlers.
-            const resolved = resolveStatelessCommandArgs(command.name(), params);
-            if (!resolved.ok) {
-                logError(resolved.error);
-                return;
-            }
-            const args = resolved.args;
-            logSuccess(`Executing command: ${command.name()}, params: ${JSON.stringify(args)}`);
-            const loading = createLoading(`Executing ${command.name()}...`);
-            try {
-                if (command.name() === 'download-kernel') {
-                    loading.stop();
-                    const result = await trackKernelDownload(fnc, args);
-                    const out = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-                    logInfo(`\n\n${out}\n\n`);
-                } else {
-                    const result = await fnc(args);
-                    const out = typeof result === 'string' ? result : JSON.stringify(result, null, 2);
-                    logInfo(`\n\n${out}\n`);
-                    if (command.name() === 'update-patch' && !out.includes('The client is already on the latest patch version. No update is required')) {
-                        loading.stop();
-                        await sleepTime(1000 * 60);
-                        await restartChild();
-                    }
-                }
-            } finally {
-                loading.stop();
-            }
+            await handleAction(params, options, command, fnc);
         });
 }
 
-program.parseAsync(process.argv).catch((error) => {
-    console.error(error);
-    process.exit(1);
-});
+setupShellCompletion(program);
+
+const shellScriptArg = process.argv[2] === 'complete' ? process.argv[3] : undefined;
+const restoreStdout = wrapShellScriptOutput(shellScriptArg);
+
+if (isShellCompletionRequest()) {
+    program.parse(process.argv);
+    restoreStdout();
+} else {
+    program.parseAsync(process.argv).catch((error) => {
+        console.error(error);
+        process.exit(1);
+    }).finally(restoreStdout);
+}

--- a/packages/adspower-browser/src/tools/index.ts
+++ b/packages/adspower-browser/src/tools/index.ts
@@ -7,7 +7,8 @@ import { exec } from "node:child_process";
 import { red, green, yellow } from 'colors';
 import { ensureDirSync, readJsonSync, outputJsonSync, removeSync, copySync } from "fs-extra2";
 
-export const VERSION = "1.0.0";
+export const VERSION = readJsonSync(path.join(__dirname, "../package.json")).version as string;
+const VERSION_FILE = "1.0.0";
 
 export const toTerminalLink = (url: string, label?: string) => {
     const text = label || url;
@@ -77,7 +78,7 @@ const getPidFileDir = () => {
 };
 
 const pidFileName = () => {
-    const md5 = crypto.createHash("md5").update(VERSION).digest("hex");
+    const md5 = crypto.createHash("md5").update(VERSION_FILE).digest("hex");
     return md5;
 };
 
@@ -217,46 +218,3 @@ export const initSqlite3 = () => {
         logSuccess(`[i] SQLite file initialized successfully!`);
     }
 }
-
-
-const renderKernelProgress = (result: any) => {
-    const status = result.status || 'pending';
-    const progress = ['completed', 'installing'].includes(status) ? 100 : Math.max(0, Math.min(100, Number(result.progress) || 0));
-
-    if (!process.stdout.isTTY) {
-        logInfo(`Kernel progress: ${progress}% [${status}]`);
-        return;
-    }
-
-    const width = 30;
-    const filled = Math.round((progress / 100) * width);
-    const bar = `${'='.repeat(filled)}${'-'.repeat(width - filled)}`;
-    process.stdout.write(`\r[${bar}] ${progress.toFixed(0).padStart(3, ' ')}% ${status}     `);
-};
-
-const finishKernelProgress = () => {
-    if (process.stdout.isTTY) {
-        process.stdout.write('\n');
-    }
-};
-
-export const trackKernelDownload = async (fnc: (params: any) => Promise<unknown>, args: Record<string, any>) => {
-    while (true) {
-        const result = await fnc(args);
-        try {
-            const resultJson: any = JSON.parse((result as string).replace('Kernel download/update status: ', ''));
-            if (resultJson && resultJson.status && ['pending', 'downloading', 'completed', 'installing', 'failed'].includes(resultJson.status)) {
-                renderKernelProgress(resultJson);
-                if (['completed', 'failed'].includes(resultJson.status)) {
-                    finishKernelProgress();
-                    return result;
-                }
-                await sleepTime(3000);
-            } else {
-                return result;
-            }
-        } catch (error) {
-            return result;
-        }
-    }
-};

--- a/packages/adspower-browser/src/tools/index.ts
+++ b/packages/adspower-browser/src/tools/index.ts
@@ -46,7 +46,7 @@ export const browsersKill = async () => {
 const taskKillBrowser = () =>
     new Promise<void>((resolve) => {
         const cmd = ["linux", "darwin"].includes(process.platform) ? 'pkill -u `whoami` -f "SunBrowser"' : "taskkill -PID SunBrowser.exe";
-        exec(cmd, (err) => {
+        exec(cmd, { windowsHide: true }, (err) => {
             if (err) {
                 // logError(`[!] Kill SunBrowser进程失败: ${err.message}`);
             }
@@ -56,7 +56,7 @@ const taskKillBrowser = () =>
 const taskKillFlowser = () =>
     new Promise<void>((resolve) => {
         const cmd = ["linux", "darwin"].includes(process.platform) ? 'pkill -u `whoami` -f "FlowerBrowser"' : "taskkill -PID FlowerBrowser.exe";
-        exec(cmd, (err) => {
+        exec(cmd, { windowsHide: true }, (err) => {
             if (err) {
                 // logError(`[!] Kill FlowerBrowser进程失败: ${err.message}`);
             }
@@ -108,6 +108,7 @@ export const isRunning = (pid: string) => {
             exec(util.format(process.platform === 'win32' ? 
                 'tasklist /fi "PID eq %s" | findstr /i "node.exe"'
                 : 'ps -f -p %s | grep "node"', pid), 
+                { windowsHide: true },
                 function (err, stdout, stderr) {
                     resolve(!err && !!stdout.toString().trim());
                 });

--- a/packages/adspower-browser/src/types/bomb-tab.d.ts
+++ b/packages/adspower-browser/src/types/bomb-tab.d.ts
@@ -1,0 +1,5 @@
+declare module '@bomb.sh/tab/commander' {
+    import type { Command } from 'commander';
+
+    export default function tab(instance: Command): unknown;
+}

--- a/packages/adspower-browser/tsup.config.ts
+++ b/packages/adspower-browser/tsup.config.ts
@@ -1,7 +1,7 @@
 import { defineConfig } from 'tsup';
 
 export default defineConfig({
-  entry: ['src/index.ts'],
+  entry: ['src/index.ts', 'src/core/winHideChildProcess.js'],
   format: ['cjs'],
   outDir: 'cli',
   sourcemap: false,

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@adspower/local-api-core",
-  "version": "1.0.6",
+  "version": "1.0.7",
   "private": true,
   "main": "src/index.ts",
   "types": "src/index.ts",
@@ -9,7 +9,7 @@
   "dependencies": {
     "axios": "^1.8.4",
     "playwright-core": "^1.51.1",
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@types/node": "^22.13.13",

--- a/packages/core/src/handlers/application.ts
+++ b/packages/core/src/handlers/application.ts
@@ -5,12 +5,12 @@ import { buildQueryParamsFor } from '../utils/requestBuilder.js';
 export const applicationHandlers = {
     async checkStatus() {
         const response = await getApiClient().get(`${getLocalApiBase()}${API_ENDPOINTS.STATUS}`);
-        return `Connection status: ${JSON.stringify(response.data, null, 2)}`;
+        return JSON.stringify(response.data, null, 2);
     },
 
     async getApplicationList(params: GetApplicationListParams) {
         const query = buildQueryParamsFor('get-application-list', params as Record<string, unknown>);
         const response = await getApiClient().get(`${getLocalApiBase()}${API_ENDPOINTS.GET_APPLICATION_LIST}`, { params: query });
-        return `Application list: ${JSON.stringify(response.data.data.list, null, 2)}`;
+        return JSON.stringify(response.data.data, null, 2);
     }
 };

--- a/packages/core/src/handlers/browser.ts
+++ b/packages/core/src/handlers/browser.ts
@@ -30,26 +30,18 @@ export const browserHandlers = {
         const requestBody = buildRequestBodyFor('open-browser', resolvedParams);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.START_BROWSER}`, requestBody);
         if (response.data.code === 0) {
-            const autoNote = didAutoSetHeadless
-                ? '\n已根据运行环境自动使用 headless=1（无可用图形会话）。\nAuto-set headless=1 (no graphical session detected).'
-                : '';
-            return `Browser opened successfully with: ${Object.entries(response.data.data).map(([key, value]) => {
-                if (value && typeof value === 'object') {
-                    return Object.entries(value).map(([key, value]) => `ws.${key}: ${value}`).join('\n');
-                }
-                return `${key}: ${value}`;
-            }).join('\n')}${autoNote}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to open browser: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async closeBrowser(params: CloseBrowserParams) {
         const requestBody = buildRequestBodyFor('close-browser', params);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.CLOSE_BROWSER}`, requestBody);
         if (response.data.code === 0) {
-            return 'Browser closed successfully';
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to close browser: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async createBrowser(params: CreateBrowserParams) {
@@ -57,9 +49,9 @@ export const browserHandlers = {
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.CREATE_BROWSER}`, requestBody);
 
         if (response.data.code === 0) {
-            return `Browser created successfully with: ${Object.entries(response.data.data).map(([key, value]) => `${key}: ${value}`).join('\n')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to create browser: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async updateBrowser(params: UpdateBrowserParams) {
@@ -67,9 +59,9 @@ export const browserHandlers = {
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.UPDATE_BROWSER}`, requestBody);
 
         if (response.data.code === 0) {
-            return `Browser updated successfully with: ${Object.entries(response.data.data || {}).map(([key, value]) => `${key}: ${value}`).join('\n')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to update browser: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async deleteBrowser(params: DeleteBrowserParams) {
@@ -79,73 +71,73 @@ export const browserHandlers = {
         );
 
         if (response.data.code === 0) {
-            return `Browsers deleted successfully: ${params.profile_id.join(', ')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to delete browsers: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getBrowserList(params: GetBrowserListParams) {
         const requestBody = buildRequestBodyFor('get-browser-list', params);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.GET_BROWSER_LIST}`, requestBody);
         if (response.data.code === 0) {
-            return `Browser list: ${JSON.stringify(response.data.data.list, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get browser list: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getOpenedBrowser() {
         const response = await getApiClient().get(`${getLocalApiBase()}${API_ENDPOINTS.GET_OPENED_BROWSER}`);
 
         if (response.data.code === 0) {
-            return `Opened browser list: ${JSON.stringify(response.data.data.list, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get opened browsers: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async moveBrowser(params: MoveBrowserParams) {
         const requestBody = buildRequestBodyFor('move-browser', params as Record<string, unknown>);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.MOVE_BROWSER}`, requestBody);
-        const { group_id, user_ids } = params as MoveBrowserParams & { group_id: string; user_ids: string[] };
+        // const { group_id, user_ids } = params as MoveBrowserParams & { group_id: string; user_ids: string[] };
 
         if (response.data.code === 0) {
-            return `Browsers moved successfully to group ${group_id}: ${user_ids.join(', ')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to move browsers: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getProfileCookies(params: GetProfileCookiesParams) {
         const query = buildQueryParamsFor('get-profile-cookies', params);
         const response = await getApiClient().get(`${getLocalApiBase()}${API_ENDPOINTS.GET_PROFILE_COOKIES}`, { params: query });
         if (response.data.code === 0) {
-            return `Profile cookies: ${JSON.stringify(response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get profile cookies: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getProfileUa(params: GetProfileUaParams) {
         const requestBody = buildRequestBodyFor('get-profile-ua', params);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.GET_PROFILE_UA}`, requestBody);
         if (response.data.code === 0) {
-            return `Profile User-Agent: ${JSON.stringify(response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get profile User-Agent: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async closeAllProfiles(_params: CloseAllProfilesParams) {
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.CLOSE_ALL_PROFILES}`, {});
-        if (response.data.code === 0) {
-            return 'All profiles closed successfully';
+        if (response.data.data.code === 0) {
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to close all profiles: ${response.data.msg}`);
+        throw new Error(response.data.data.msg);
     },
 
     async newFingerprint(params: NewFingerprintParams) {
         const requestBody = buildRequestBodyFor('new-fingerprint', params);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.NEW_FINGERPRINT}`, requestBody);
         if (response.data.code === 0) {
-            return `New fingerprint created: ${JSON.stringify(response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to create new fingerprint: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async deleteCacheV2(params: DeleteCacheV2Params) {
@@ -154,35 +146,35 @@ export const browserHandlers = {
             buildRequestBodyFor('delete-cache-v2', params)
         );
         if (response.data.code === 0) {
-            return `Cache deleted successfully for profiles: ${params.profile_id.join(', ')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to delete cache: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async shareProfile(params: ShareProfileParams) {
         const requestBody = buildRequestBodyFor('share-profile', params);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.SHARE_PROFILE}`, requestBody);
         if (response.data.code === 0) {
-            return `Profiles shared successfully: ${params.profile_id.join(', ')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to share profiles: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getBrowserActive(params: GetBrowserActiveParams) {
         const query = buildQueryParamsFor('get-browser-active', params);
         const response = await getApiClient().get(`${getLocalApiBase()}${API_ENDPOINTS.GET_BROWSER_ACTIVE}`, { params: query });
         if (response.data.code === 0) {
-            return `Browser active info: ${JSON.stringify(response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get browser active: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getCloudActive(params: GetCloudActiveParams) {
         const requestBody = buildRequestBodyFor('get-cloud-active', params as Record<string, unknown>);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.GET_CLOUD_ACTIVE}`, requestBody);
         if (response.data.code === 0) {
-            return `Cloud active browsers: ${JSON.stringify(response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get cloud active browsers: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     }
 };

--- a/packages/core/src/handlers/group.ts
+++ b/packages/core/src/handlers/group.ts
@@ -10,31 +10,29 @@ export const groupHandlers = {
     async createGroup(params: CreateGroupParams) {
         const requestBody = buildRequestBodyFor('create-group', params as Record<string, unknown>);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.CREATE_GROUP}`, requestBody);
-        const { group_name, remark } = params;
 
         if (response.data.code === 0) {
-            return `Group created successfully with name: ${group_name}${remark ? `, remark: ${remark}` : ''}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to create group: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async updateGroup(params: UpdateGroupParams) {
         const requestBody = buildRequestBodyFor('update-group', params as Record<string, unknown>);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.UPDATE_GROUP}`, requestBody);
-        const { group_id, group_name, remark } = params;
 
         if (response.data.code === 0) {
-            return `Group updated successfully with id: ${group_id}, name: ${group_name}${remark !== undefined ? `, remark: ${remark === null ? '(cleared)' : remark}` : ''}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to update group: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getGroupList(params: GetGroupListParams) {
         const query = buildQueryParamsFor('get-group-list', params as Record<string, unknown>);
         const response = await getApiClient().get(`${getLocalApiBase()}${API_ENDPOINTS.GET_GROUP_LIST}`, { params: query });
         if (response.data.code === 0) {
-            return `Group list: ${JSON.stringify(response.data.data.list, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get group list: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     }
 };

--- a/packages/core/src/handlers/kernel.ts
+++ b/packages/core/src/handlers/kernel.ts
@@ -9,10 +9,9 @@ export const kernelHandlers = {
         });
 
         if (response.data.code === 0) {
-            return `Kernel download/update status: ${JSON.stringify(response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-
-        throw new Error(`Failed to download/update kernel: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getKernelList({ kernel_type }: GetKernelListParams) {
@@ -23,10 +22,9 @@ export const kernelHandlers = {
 
         const response = await getApiClient().get(`${getLocalApiBase()}${API_ENDPOINTS.GET_KERNEL_LIST}`, { params });
         if (response.data.code === 0) {
-            return `Kernel list: ${JSON.stringify(response.data.data.list || response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-
-        throw new Error(`Failed to get kernel list: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     }
 };
 

--- a/packages/core/src/handlers/patch.ts
+++ b/packages/core/src/handlers/patch.ts
@@ -10,10 +10,9 @@ export const patchHandlers = {
 
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.UPDATE_PATCH}`, requestBody);
         if (response.data.code === 0) {
-            return `Patch update status: ${JSON.stringify(response.data.data, null, 2)}, message: ${response.data.msg}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-
-        throw new Error(`Failed to update patch: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     }
 };
 

--- a/packages/core/src/handlers/proxy.ts
+++ b/packages/core/src/handlers/proxy.ts
@@ -5,6 +5,7 @@ import type {
     GetProxyListParams,
     DeleteProxyParams
 } from '../types/proxy.js';
+import { schemas } from '../types/schemas.js';
 import { buildRequestBodyFor } from '../utils/requestBuilder.js';
 
 type ProxyItem = CreateProxyParams[number];
@@ -41,9 +42,9 @@ export const proxyHandlers = {
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.CREATE_PROXY}`, requestBody);
 
         if (response.data.code === 0) {
-            return `Proxy created successfully with: ${Object.entries(response.data.data || {}).map(([key, value]) => `${key}: ${value}`).join('\n')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to create proxy: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async updateProxy(params: UpdateProxyParams) {
@@ -51,18 +52,18 @@ export const proxyHandlers = {
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.UPDATE_PROXY}`, requestBody);
 
         if (response.data.code === 0) {
-            return `Proxy updated successfully with: ${Object.entries(response.data.data || {}).map(([key, value]) => `${key}: ${value}`).join('\n')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to update proxy: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async getProxyList(params: GetProxyListParams) {
         const requestBody = buildRequestBodyFor('get-proxy-list', params as Record<string, unknown>);
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.GET_PROXY_LIST}`, requestBody);
         if (response.data.code === 0) {
-            return `Proxy list: ${JSON.stringify(response.data.data.list || response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get proxy list: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async deleteProxy(params: DeleteProxyParams) {
@@ -73,8 +74,8 @@ export const proxyHandlers = {
         const { proxy_id } = params as DeleteProxyParams & { proxy_id: string[] };
 
         if (response.data.code === 0) {
-            return `Proxies deleted successfully: ${proxy_id.join(', ')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to delete proxies: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     }
 };

--- a/packages/core/src/handlers/tag.ts
+++ b/packages/core/src/handlers/tag.ts
@@ -18,32 +18,32 @@ export const tagHandlers = {
 
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.GET_TAG_LIST}`, requestBody);
         if (response.data.code === 0) {
-            return `Tag list: ${JSON.stringify(response.data.data.list || response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to get tag list: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async createTag({ tags }: CreateTagParams) {
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.CREATE_TAG}`, { tags });
         if (response.data.code === 0) {
-            return `Tags created successfully: ${JSON.stringify(response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to create tags: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async updateTag({ tags }: UpdateTagParams) {
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.UPDATE_TAG}`, { tags });
         if (response.data.code === 0) {
-            return `Tags updated successfully: ${JSON.stringify(response.data.data, null, 2)}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to update tags: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     },
 
     async deleteTag({ ids }: DeleteTagParams) {
         const response = await getApiClient().post(`${getLocalApiBase()}${API_ENDPOINTS.DELETE_TAG}`, { ids });
         if (response.data.code === 0) {
-            return `Tags deleted successfully: ${ids.join(', ')}`;
+            return JSON.stringify(response.data.data, null, 2);
         }
-        throw new Error(`Failed to delete tags: ${response.data.msg}`);
+        throw new Error(response.data.msg);
     }
 };

--- a/packages/local-api-mcp/package.json
+++ b/packages/local-api-mcp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "local-api-mcp-typescript",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "main": "build/index.js",
   "type": "commonjs",
   "bin": {
@@ -18,7 +18,7 @@
     "@modelcontextprotocol/sdk": "^1.7.0",
     "axios": "^1.8.4",
     "playwright-core": "^1.51.1",
-    "zod": "^3.24.2"
+    "zod": "^4.4.3"
   },
   "devDependencies": {
     "@adspower/local-api-core": "workspace:*",

--- a/packages/local-api-mcp/src/utils/toolRegister.ts
+++ b/packages/local-api-mcp/src/utils/toolRegister.ts
@@ -14,6 +14,9 @@ import {
 import { wrapHandler } from './handlerWrapper.js';
 import { z } from 'zod';
 
+// @modelcontextprotocol/sdk types tool inputs against Zod 3 shapes; Zod 4 is runtime-compatible.
+type McpToolInputShape = Parameters<McpServer['tool']>[2];
+
 function getSchemaShape(schema: z.ZodTypeAny): Record<string, z.ZodTypeAny> {
     if ('shape' in schema && typeof schema.shape === 'object' && schema.shape !== null) {
         return schema.shape as Record<string, z.ZodTypeAny>;
@@ -30,144 +33,144 @@ function getSchemaShape(schema: z.ZodTypeAny): Record<string, z.ZodTypeAny> {
 }
 
 export function registerTools(server: McpServer) {
-    server.tool('open-browser', buildMcpToolDescription('open-browser', 'Open the browser, both environment and profile mean browser'), getSchemaShape(schemas.openBrowserSchema),
+    server.tool('open-browser', buildMcpToolDescription('open-browser', 'Open the browser, both environment and profile mean browser'), getSchemaShape(schemas.openBrowserSchema) as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.openBrowser));
 
-    server.tool('close-browser', buildMcpToolDescription('close-browser', 'Close the browser'), getSchemaShape(schemas.closeBrowserSchema),
+    server.tool('close-browser', buildMcpToolDescription('close-browser', 'Close the browser'), getSchemaShape(schemas.closeBrowserSchema) as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.closeBrowser));
 
-    server.tool('create-browser', buildMcpToolDescription('create-browser', 'Create a browser'), getSchemaShape(schemas.createBrowserSchema),
+    server.tool('create-browser', buildMcpToolDescription('create-browser', 'Create a browser'), getSchemaShape(schemas.createBrowserSchema) as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.createBrowser));
 
-    server.tool('update-browser', buildMcpToolDescription('update-browser', 'Update the browser'), schemas.updateBrowserSchema.shape,
+    server.tool('update-browser', buildMcpToolDescription('update-browser', 'Update the browser'), schemas.updateBrowserSchema.shape as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.updateBrowser));
 
-    server.tool('delete-browser', buildMcpToolDescription('delete-browser', 'Delete the browser'), schemas.deleteBrowserSchema.shape,
+    server.tool('delete-browser', buildMcpToolDescription('delete-browser', 'Delete the browser'), schemas.deleteBrowserSchema.shape as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.deleteBrowser));
 
-    server.tool('get-browser-list', buildMcpToolDescription('get-browser-list', 'Get the list of browsers'), schemas.getBrowserListSchema.shape,
+    server.tool('get-browser-list', buildMcpToolDescription('get-browser-list', 'Get the list of browsers'), schemas.getBrowserListSchema.shape as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.getBrowserList));
 
-    server.tool('get-opened-browser', buildMcpToolDescription('get-opened-browser', 'Get the list of opened browsers'), schemas.emptySchema.shape,
+    server.tool('get-opened-browser', buildMcpToolDescription('get-opened-browser', 'Get the list of opened browsers'), schemas.emptySchema.shape as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.getOpenedBrowser));
 
-    server.tool('move-browser', buildMcpToolDescription('move-browser', 'Move browsers to a group'), schemas.moveBrowserSchema.shape,
+    server.tool('move-browser', buildMcpToolDescription('move-browser', 'Move browsers to a group'), schemas.moveBrowserSchema.shape as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.moveBrowser));
 
-    server.tool('get-profile-cookies', buildMcpToolDescription('get-profile-cookies', 'Query and return cookies of the specified profile. Only one profile can be queried per request.'), getSchemaShape(schemas.getProfileCookiesSchema),
+    server.tool('get-profile-cookies', buildMcpToolDescription('get-profile-cookies', 'Query and return cookies of the specified profile. Only one profile can be queried per request.'), getSchemaShape(schemas.getProfileCookiesSchema) as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.getProfileCookies));
 
-    server.tool('get-profile-ua', buildMcpToolDescription('get-profile-ua', 'Query and return the User-Agent of specified profiles. Up to 10 profiles can be queried per request.'), getSchemaShape(schemas.getProfileUaSchema),
+    server.tool('get-profile-ua', buildMcpToolDescription('get-profile-ua', 'Query and return the User-Agent of specified profiles. Up to 10 profiles can be queried per request.'), getSchemaShape(schemas.getProfileUaSchema) as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.getProfileUa));
 
-    server.tool('close-all-profiles', buildMcpToolDescription('close-all-profiles', 'Close all opened profiles on the current device'), schemas.closeAllProfilesSchema.shape,
+    server.tool('close-all-profiles', buildMcpToolDescription('close-all-profiles', 'Close all opened profiles on the current device'), schemas.closeAllProfilesSchema.shape as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.closeAllProfiles));
 
-    server.tool('new-fingerprint', buildMcpToolDescription('new-fingerprint', 'Generate a new fingerprint for specified profiles. Up to 10 profiles are supported per request.'), getSchemaShape(schemas.newFingerprintSchema),
+    server.tool('new-fingerprint', buildMcpToolDescription('new-fingerprint', 'Generate a new fingerprint for specified profiles. Up to 10 profiles are supported per request.'), getSchemaShape(schemas.newFingerprintSchema) as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.newFingerprint));
 
-    server.tool('delete-cache-v2', buildMcpToolDescription('delete-cache-v2', 'Clear local cache of specific profiles.For account security, please ensure that there are no open browsers on the device when using this interface.'), schemas.deleteCacheV2Schema.shape,
+    server.tool('delete-cache-v2', buildMcpToolDescription('delete-cache-v2', 'Clear local cache of specific profiles.For account security, please ensure that there are no open browsers on the device when using this interface.'), schemas.deleteCacheV2Schema.shape as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.deleteCacheV2));
 
-    server.tool('share-profile', buildMcpToolDescription('share-profile', 'Share profiles via account email or phone number. The maximum number of profiles that can be shared at one time is 200.'), schemas.shareProfileSchema.shape,
+    server.tool('share-profile', buildMcpToolDescription('share-profile', 'Share profiles via account email or phone number. The maximum number of profiles that can be shared at one time is 200.'), schemas.shareProfileSchema.shape as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.shareProfile));
 
-    server.tool('get-browser-active', buildMcpToolDescription('get-browser-active', 'Get active browser profile information'), getSchemaShape(schemas.getBrowserActiveSchema),
+    server.tool('get-browser-active', buildMcpToolDescription('get-browser-active', 'Get active browser profile information'), getSchemaShape(schemas.getBrowserActiveSchema) as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.getBrowserActive));
 
-    server.tool('get-cloud-active', buildMcpToolDescription('get-cloud-active', 'Query the status of browser profiles by user_ids, up to 100 profiles per request. If the team has enabled "Multi device mode," specific statuses cannot be retrieved and the response will indicate "Profile not opened."'), getSchemaShape(schemas.getCloudActiveSchema),
+    server.tool('get-cloud-active', buildMcpToolDescription('get-cloud-active', 'Query the status of browser profiles by user_ids, up to 100 profiles per request. If the team has enabled "Multi device mode," specific statuses cannot be retrieved and the response will indicate "Profile not opened."'), getSchemaShape(schemas.getCloudActiveSchema) as unknown as McpToolInputShape,
         wrapHandler(browserHandlers.getCloudActive));
 
-    server.tool('create-group', buildMcpToolDescription('create-group', 'Create a browser group'), schemas.createGroupSchema.shape,
+    server.tool('create-group', buildMcpToolDescription('create-group', 'Create a browser group'), schemas.createGroupSchema.shape as unknown as McpToolInputShape,
         wrapHandler(groupHandlers.createGroup));
 
-    server.tool('update-group', buildMcpToolDescription('update-group', 'Update the browser group'), schemas.updateGroupSchema.shape,
+    server.tool('update-group', buildMcpToolDescription('update-group', 'Update the browser group'), schemas.updateGroupSchema.shape as unknown as McpToolInputShape,
         wrapHandler(groupHandlers.updateGroup));
 
-    server.tool('get-group-list', buildMcpToolDescription('get-group-list', 'Get the list of groups'), schemas.getGroupListSchema.shape,
+    server.tool('get-group-list', buildMcpToolDescription('get-group-list', 'Get the list of groups'), schemas.getGroupListSchema.shape as unknown as McpToolInputShape,
         wrapHandler(groupHandlers.getGroupList));
 
-    server.tool('check-status', buildMcpToolDescription('check-status', 'Check the availability of the current device API interface (Connection Status)'), schemas.emptySchema.shape,
+    server.tool('check-status', buildMcpToolDescription('check-status', 'Check the availability of the current device API interface (Connection Status)'), schemas.emptySchema.shape as unknown as McpToolInputShape,
         wrapHandler(applicationHandlers.checkStatus));
 
-    server.tool('get-application-list', buildMcpToolDescription('get-application-list', 'Get application categories with optional category_id filtering and page/limit pagination.'), schemas.getApplicationListSchema.shape,
+    server.tool('get-application-list', buildMcpToolDescription('get-application-list', 'Get application categories with optional category_id filtering and page/limit pagination.'), schemas.getApplicationListSchema.shape as unknown as McpToolInputShape,
         wrapHandler(applicationHandlers.getApplicationList));
 
-    server.tool('create-proxy', buildMcpToolDescription('create-proxy', 'Create a proxy'), getSchemaShape(schemas.createProxyMcpSchema),
+    server.tool('create-proxy', buildMcpToolDescription('create-proxy', 'Create a proxy'), getSchemaShape(schemas.createProxyMcpSchema) as unknown as McpToolInputShape,
         wrapHandler((params: { proxies: Parameters<typeof proxyHandlers.createProxy>[0] }) => proxyHandlers.createProxy(params.proxies)));
 
-    server.tool('update-proxy', buildMcpToolDescription('update-proxy', 'Update the proxy'), getSchemaShape(schemas.updateProxySchema),
+    server.tool('update-proxy', buildMcpToolDescription('update-proxy', 'Update the proxy'), getSchemaShape(schemas.updateProxySchema) as unknown as McpToolInputShape,
         wrapHandler(proxyHandlers.updateProxy));
 
-    server.tool('get-proxy-list', buildMcpToolDescription('get-proxy-list', 'Get the list of proxies'), schemas.getProxyListSchema.shape,
+    server.tool('get-proxy-list', buildMcpToolDescription('get-proxy-list', 'Get the list of proxies'), schemas.getProxyListSchema.shape as unknown as McpToolInputShape,
         wrapHandler(proxyHandlers.getProxyList));
 
-    server.tool('delete-proxy', buildMcpToolDescription('delete-proxy', 'Delete the proxy'), schemas.deleteProxySchema.shape,
+    server.tool('delete-proxy', buildMcpToolDescription('delete-proxy', 'Delete the proxy'), schemas.deleteProxySchema.shape as unknown as McpToolInputShape,
         wrapHandler(proxyHandlers.deleteProxy));
 
-    server.tool('get-tag-list', buildMcpToolDescription('get-tag-list', 'Get the list of browser tags'), schemas.getTagListSchema.shape,
+    server.tool('get-tag-list', buildMcpToolDescription('get-tag-list', 'Get the list of browser tags'), schemas.getTagListSchema.shape as unknown as McpToolInputShape,
         wrapHandler(tagHandlers.getTagList));
 
-    server.tool('create-tag', buildMcpToolDescription('create-tag', 'Create browser tags (batch supported)'), schemas.createTagSchema.shape,
+    server.tool('create-tag', buildMcpToolDescription('create-tag', 'Create browser tags (batch supported)'), schemas.createTagSchema.shape as unknown as McpToolInputShape,
         wrapHandler(tagHandlers.createTag));
 
-    server.tool('update-tag', buildMcpToolDescription('update-tag', 'Update browser tags (batch supported)'), schemas.updateTagSchema.shape,
+    server.tool('update-tag', buildMcpToolDescription('update-tag', 'Update browser tags (batch supported)'), schemas.updateTagSchema.shape as unknown as McpToolInputShape,
         wrapHandler(tagHandlers.updateTag));
 
-    server.tool('delete-tag', buildMcpToolDescription('delete-tag', 'Delete browser tags'), schemas.deleteTagSchema.shape,
+    server.tool('delete-tag', buildMcpToolDescription('delete-tag', 'Delete browser tags'), schemas.deleteTagSchema.shape as unknown as McpToolInputShape,
         wrapHandler(tagHandlers.deleteTag));
 
-    server.tool('download-kernel', buildMcpToolDescription('download-kernel', 'Download or update a browser kernel version'), schemas.downloadKernelSchema.shape,
+    server.tool('download-kernel', buildMcpToolDescription('download-kernel', 'Download or update a browser kernel version'), schemas.downloadKernelSchema.shape as unknown as McpToolInputShape,
         wrapHandler(kernelHandlers.downloadKernel));
 
-    server.tool('get-kernel-list', buildMcpToolDescription('get-kernel-list', 'Get browser kernel list by type or all'), schemas.getKernelListSchema.shape,
+    server.tool('get-kernel-list', buildMcpToolDescription('get-kernel-list', 'Get browser kernel list by type or all'), schemas.getKernelListSchema.shape as unknown as McpToolInputShape ,
         wrapHandler(kernelHandlers.getKernelList));
 
-    server.tool('update-patch', buildMcpToolDescription('update-patch', 'Update AdsPower to latest patch version'), schemas.updatePatchSchema.shape,
+    server.tool('update-patch', buildMcpToolDescription('update-patch', 'Update AdsPower to latest patch version'), schemas.updatePatchSchema.shape as unknown as McpToolInputShape,
         wrapHandler(patchHandlers.updatePatch));
 
-    server.tool('connect-browser-with-ws', buildMcpToolDescription('connect-browser-with-ws', 'Connect the browser with the ws url'), schemas.createAutomationSchema.shape,
+    server.tool('connect-browser-with-ws', buildMcpToolDescription('connect-browser-with-ws', 'Connect the browser with the ws url'), schemas.createAutomationSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.connectBrowserWithWs));
 
-    server.tool('open-new-page', buildMcpToolDescription('open-new-page', 'Open a new page'), schemas.emptySchema.shape,
+    server.tool('open-new-page', buildMcpToolDescription('open-new-page', 'Open a new page'), schemas.emptySchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.openNewPage));
 
-    server.tool('navigate', buildMcpToolDescription('navigate', 'Navigate to the url'), schemas.navigateSchema.shape,
+    server.tool('navigate', buildMcpToolDescription('navigate', 'Navigate to the url'), schemas.navigateSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.navigate));
 
-    server.tool('screenshot', buildMcpToolDescription('screenshot', 'Get the screenshot of the page'), schemas.screenshotSchema.shape,
+    server.tool('screenshot', buildMcpToolDescription('screenshot', 'Get the screenshot of the page'), schemas.screenshotSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.screenshot));
 
-    server.tool('get-page-visible-text', buildMcpToolDescription('get-page-visible-text', 'Get the visible text content of the page'), schemas.emptySchema.shape,
+    server.tool('get-page-visible-text', buildMcpToolDescription('get-page-visible-text', 'Get the visible text content of the page'), schemas.emptySchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.getPageVisibleText));
 
-    server.tool('get-page-html', buildMcpToolDescription('get-page-html', 'Get the html content of the page'), schemas.emptySchema.shape,
+    server.tool('get-page-html', buildMcpToolDescription('get-page-html', 'Get the html content of the page'), schemas.emptySchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.getPageHtml));
 
-    server.tool('click-element', buildMcpToolDescription('click-element', 'Click the element'), schemas.clickElementSchema.shape,
+    server.tool('click-element', buildMcpToolDescription('click-element', 'Click the element'), schemas.clickElementSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.clickElement));
 
-    server.tool('fill-input', buildMcpToolDescription('fill-input', 'Fill the input'), schemas.fillInputSchema.shape,
+    server.tool('fill-input', buildMcpToolDescription('fill-input', 'Fill the input'), schemas.fillInputSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.fillInput));
 
-    server.tool('select-option', buildMcpToolDescription('select-option', 'Select the option'), schemas.selectOptionSchema.shape,
+    server.tool('select-option', buildMcpToolDescription('select-option', 'Select the option'), schemas.selectOptionSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.selectOption));
 
-    server.tool('hover-element', buildMcpToolDescription('hover-element', 'Hover the element'), schemas.hoverElementSchema.shape,
+    server.tool('hover-element', buildMcpToolDescription('hover-element', 'Hover the element'), schemas.hoverElementSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.hoverElement));
 
-    server.tool('scroll-element', buildMcpToolDescription('scroll-element', 'Scroll the element'), schemas.scrollElementSchema.shape,
+    server.tool('scroll-element', buildMcpToolDescription('scroll-element', 'Scroll the element'), schemas.scrollElementSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.scrollElement));
 
-    server.tool('press-key', buildMcpToolDescription('press-key', 'Press the key'), schemas.pressKeySchema.shape,
+    server.tool('press-key', buildMcpToolDescription('press-key', 'Press the key'), schemas.pressKeySchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.pressKey));
 
-    server.tool('evaluate-script', buildMcpToolDescription('evaluate-script', 'Evaluate the script'), schemas.evaluateScriptSchema.shape,
+    server.tool('evaluate-script', buildMcpToolDescription('evaluate-script', 'Evaluate the script'), schemas.evaluateScriptSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.evaluateScript));
 
-    server.tool('drag-element', buildMcpToolDescription('drag-element', 'Drag the element'), schemas.dragElementSchema.shape,
+    server.tool('drag-element', buildMcpToolDescription('drag-element', 'Drag the element'), schemas.dragElementSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.dragElement));
 
-    server.tool('iframe-click-element', buildMcpToolDescription('iframe-click-element', 'Click the element in the iframe'), schemas.iframeClickElementSchema.shape,
+    server.tool('iframe-click-element', buildMcpToolDescription('iframe-click-element', 'Click the element in the iframe'), schemas.iframeClickElementSchema.shape as unknown as McpToolInputShape,
         wrapHandler(automationHandlers.iframeClickElement));
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   packages/adspower-browser:
     dependencies:
+      '@bomb.sh/tab':
+        specifier: ^0.0.15
+        version: 0.0.15(cac@6.7.14)(commander@14.0.3)
       axios:
         specifier: ^1.8.4
         version: 1.8.4
@@ -33,8 +36,8 @@ importers:
         specifier: ^1.51.1
         version: 1.51.1
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@adspower/local-api-core':
         specifier: workspace:*
@@ -58,8 +61,8 @@ importers:
         specifier: ^1.51.1
         version: 1.51.1
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@types/node':
         specifier: ^22.13.13
@@ -80,8 +83,8 @@ importers:
         specifier: ^1.51.1
         version: 1.51.1
       zod:
-        specifier: ^3.24.2
-        version: 3.24.2
+        specifier: ^4.4.3
+        version: 4.4.3
     devDependencies:
       '@adspower/local-api-core':
         specifier: workspace:*
@@ -97,6 +100,21 @@ importers:
         version: 5.8.2
 
 packages:
+
+  '@bomb.sh/tab@0.0.15':
+    resolution: {integrity: sha512-Y90ub44TAvbdO9P8mcD/XPyQjFhiR5xmd4Fk7JErmWmEWEUimNnjWiBrVZ16Tj3GA1rLZ+uvCN2V/pzLawv31g==}
+    hasBin: true
+    peerDependencies:
+      cac: ^6.7.14
+      citty: ^0.1.6 || ^0.2.0
+      commander: ^13.1.0
+    peerDependenciesMeta:
+      cac:
+        optional: true
+      citty:
+        optional: true
+      commander:
+        optional: true
 
   '@esbuild/aix-ppc64@0.27.2':
     resolution: {integrity: sha512-GZMB+a0mOMZs4MpDbj8RJp4cw+w1WV5NYD6xzgvzUJ5Ek2jerwfO2eADyI6ExDSUED+1X8aMbegahsJi+8mgpw==}
@@ -305,66 +323,79 @@ packages:
     resolution: {integrity: sha512-F8sWbhZ7tyuEfsmOxwc2giKDQzN3+kuBLPwwZGyVkLlKGdV1nvnNwYD0fKQ8+XS6hp9nY7B+ZeK01EBUE7aHaw==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.57.1':
     resolution: {integrity: sha512-rGfNUfn0GIeXtBP1wL5MnzSj98+PZe/AXaGBCRmT0ts80lU5CATYGxXukeTX39XBKsxzFpEeK+Mrp9faXOlmrw==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.57.1':
     resolution: {integrity: sha512-MMtej3YHWeg/0klK2Qodf3yrNzz6CGjo2UntLvk2RSPlhzgLvYEB3frRvbEF2wRKh1Z2fDIg9KRPe1fawv7C+g==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.57.1':
     resolution: {integrity: sha512-1a/qhaaOXhqXGpMFMET9VqwZakkljWHLmZOX48R0I/YLbhdxr1m4gtG1Hq7++VhVUmf+L3sTAf9op4JlhQ5u1Q==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.57.1':
     resolution: {integrity: sha512-QWO6RQTZ/cqYtJMtxhkRkidoNGXc7ERPbZN7dVW5SdURuLeVU7lwKMpo18XdcmpWYd0qsP1bwKPf7DNSUinhvA==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-loong64-musl@4.57.1':
     resolution: {integrity: sha512-xpObYIf+8gprgWaPP32xiN5RVTi/s5FCR+XMXSKmhfoJjrpRAjCuuqQXyxUa/eJTdAE6eJ+KDKaoEqjZQxh3Gw==}
     cpu: [loong64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-ppc64-gnu@4.57.1':
     resolution: {integrity: sha512-4BrCgrpZo4hvzMDKRqEaW1zeecScDCR+2nZ86ATLhAoJ5FQ+lbHVD3ttKe74/c7tNT9c6F2viwB3ufwp01Oh2w==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-musl@4.57.1':
     resolution: {integrity: sha512-NOlUuzesGauESAyEYFSe3QTUguL+lvrN1HtwEEsU2rOwdUDeTMJdO5dUYl/2hKf9jWydJrO9OL/XSSf65R5+Xw==}
     cpu: [ppc64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-riscv64-gnu@4.57.1':
     resolution: {integrity: sha512-ptA88htVp0AwUUqhVghwDIKlvJMD/fmL/wrQj99PRHFRAG6Z5nbWoWG4o81Nt9FT+IuqUQi+L31ZKAFeJ5Is+A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.57.1':
     resolution: {integrity: sha512-S51t7aMMTNdmAMPpBg7OOsTdn4tySRQvklmL3RpDRyknk87+Sp3xaumlatU+ppQ+5raY7sSTcC2beGgvhENfuw==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.57.1':
     resolution: {integrity: sha512-Bl00OFnVFkL82FHbEqy3k5CUCKH6OEJL54KCyx2oqsmZnFTR8IoNqBF+mjQVcRCT5sB6yOvK8A37LNm/kPJiZg==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.57.1':
     resolution: {integrity: sha512-ABca4ceT4N+Tv/GtotnWAeXZUZuM/9AQyCyKYyKnpk4yoA7QIAuBt6Hkgpw8kActYlew2mvckXkvx0FfoInnLg==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.57.1':
     resolution: {integrity: sha512-HFps0JeGtuOR2convgRRkHCekD7j+gdAuXM+/i6kGzQtFhlCtQkpwtNzkNj6QhCDp7DRJ7+qC/1Vg2jt5iSOFw==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-openbsd-x64@4.57.1':
     resolution: {integrity: sha512-H+hXEv9gdVQuDTgnqD+SQffoWoc0Of59AStSzTEj/feWTBAnSfSD3+Dql1ZruJQxmykT/JVY0dE8Ka7z0DH1hw==}
@@ -1192,7 +1223,15 @@ packages:
   zod@3.24.2:
     resolution: {integrity: sha512-lY7CDW43ECgW9u1TcT3IoXHflywfVqDYze4waEz812jR/bZ8FHDsl7pFQoSZTz5N+2NqRXs8GBwnAwo3ZNxqhQ==}
 
+  zod@4.4.3:
+    resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
+
 snapshots:
+
+  '@bomb.sh/tab@0.0.15(cac@6.7.14)(commander@14.0.3)':
+    optionalDependencies:
+      cac: 6.7.14
+      commander: 14.0.3
 
   '@esbuild/aix-ppc64@0.27.2':
     optional: true
@@ -2187,3 +2226,5 @@ snapshots:
       zod: 3.24.2
 
   zod@3.24.2: {}
+
+  zod@4.4.3: {}

--- a/skills/adspower-browser/references/browser-profile-management.md
+++ b/skills/adspower-browser/references/browser-profile-management.md
@@ -24,8 +24,8 @@
 
 - **group_id** (required): Numeric string; use `"0"` for Ungrouped. Get list via get-group-list.
 - At least one of **username**, **password**, **cookie**, **fakey** (required): Account information.
-- **user_proxy_config** (optional, default `{"proxy_soft":"no_proxy"}`): Inline proxy config (see [user-proxy-config.md](user-proxy-config.md)). Ignored when **proxyid** is also provided.
-- **proxyid** (optional): Saved proxy ID or `"random"`. Takes priority over **user_proxy_config** when both are given.
+- **user_proxy_config** (required when **proxyid** is not provided; default `{"proxy_soft":"no_proxy"}`): Inline proxy config (see [user-proxy-config.md](user-proxy-config.md)). When **proxyid** is present, this field is ignored.
+- **proxyid** (optional): Saved proxy ID or `"random"`. Takes priority over **user_proxy_config**; when provided, **user_proxy_config** may be omitted.
 - **name** (optional, max 100): Account name.
 - **platform** (optional): Platform domain, e.g. facebook.com.
 - **remark** (optional, max 1500): Remarks.


### PR DESCRIPTION
- 集成 @bomb.sh/tab，支持 ads/adspower/adspower-browser 的 zsh/bash 补全
- 抽取 handleAction，在内核未就绪、profile 不存在等场景提供交互式引导
- CLI help 展示 Zod Schema 参数说明，版本号改为从 package.json 读取
- 统一 core handlers 返回纯 JSON，升级 Zod 4 并适配 MCP 工具注册
- 版本号 2.0.2 → 2.0.4