### PR TITLE
补齐浏览器列表默认分页并完善代理配置文档

### DIFF
--- a/packages/adspower-browser/README.MD
+++ b/packages/adspower-browser/README.MD
@@ -142,7 +142,7 @@ ads close-browser <profile_id>                   # Or JSON: profile_id? | profil
 ads create-browser '{"group_id":"0","user_proxy_config":{"proxy_soft":"no_proxy"},...}'  # group_id + account field required; proxy optional (defaults to no_proxy; proxyid takes priority over user_proxy_config when both given)
 ads update-browser '{"profile_id":"...",...}'    # profile_id required
 ads delete-browser '{"profile_id":["..."]}'     # profile_id required
-ads get-browser-list '{}'                       # Or group_id?, limit?, page?, profile_id[]?, profile_no[]?, sort_type?, sort_order?, tag_ids?, tags_filter?, name?, name_filter?
+ads get-browser-list '{}'                       # CLI defaults to page=1,limit=200. Or group_id?, limit?, page?, profile_id[]?, profile_no[]?, sort_type?, sort_order?, tag_ids?, tags_filter?, name?, name_filter?
 ads get-opened-browser                          # No params
 ```
 

--- a/packages/core/src/constants/localApiContracts.ts
+++ b/packages/core/src/constants/localApiContracts.ts
@@ -37,6 +37,7 @@ export type ParamLocation = 'body' | 'query';
 export type ContractParam = {
     apiName: string;
     location: ParamLocation;
+    default?: unknown;
 };
 
 export type LocalApiContract = {
@@ -157,8 +158,8 @@ export const LOCAL_API_CONTRACTS: Record<ContractCommand, LocalApiContract> = {
         path: '/api/v2/browser-profile/list',
         params: {
             group_id: { apiName: 'group_id', location: 'body' },
-            limit: { apiName: 'limit', location: 'body' },
-            page: { apiName: 'page', location: 'body' },
+            limit: { apiName: 'limit', location: 'body', default: 200 },
+            page: { apiName: 'page', location: 'body', default: 1 },
             profile_id: { apiName: 'profile_id', location: 'body' },
             profile_no: { apiName: 'profile_no', location: 'body' },
             sort_type: { apiName: 'sort_type', location: 'body' },

--- a/packages/core/src/types/schemas.ts
+++ b/packages/core/src/types/schemas.ts
@@ -318,8 +318,8 @@ export const schemas = {
             .regex(/^\d+$/, "Group ID must be a numeric string")
             .optional()
             .describe('Query by group ID; searches all groups if empty'),
-        limit: z.number().min(1).max(200).optional().describe('Profiles per page. Number of profiles returned per page, range 1 ~ 200, default is 50'),
-        page: z.number().min(1).optional().describe('Page number for results, default is 1'),
+        limit: z.number().min(1).max(200).optional().describe('Profiles per page, range 1 ~ 200. If omitted the CLI sends limit=200; the Local API itself defaults to only 1, so always rely on this CLI default or pass an explicit value'),
+        page: z.number().min(1).optional().describe('Page number for results. If omitted the CLI sends page=1'),
         profile_id: nonEmptyStringArraySchema.optional().describe('Query by profile ID. Example: ["h1yynkm","h1yynks"]'),
         profile_no: nonEmptyStringArraySchema.optional().describe('Query by profile number. Example: ["123","124"]'),
         sort_type: z.enum(['profile_no', 'last_open_time', 'created_time']).optional()

--- a/packages/core/src/utils/requestBuilder.ts
+++ b/packages/core/src/utils/requestBuilder.ts
@@ -36,6 +36,10 @@ function toContractValue(value: unknown): unknown {
     return value;
 }
 
+function withContractDefault(value: unknown, defaultValue: unknown): unknown {
+    return value === undefined ? defaultValue : value;
+}
+
 export function buildRequestBodyFor(command: ContractCommand, params: Record<string, unknown>): Record<string, unknown> {
     const requestBody: Record<string, unknown> = {};
     const contract = LOCAL_API_CONTRACTS[command];
@@ -45,7 +49,7 @@ export function buildRequestBodyFor(command: ContractCommand, params: Record<str
             return;
         }
 
-        const value = params[inputName];
+        const value = withContractDefault(params[inputName], config.default);
         if (value !== undefined) {
             requestBody[config.apiName] = toContractValue(value);
         }
@@ -63,7 +67,7 @@ export function buildQueryParamsFor(command: ContractCommand, params: Record<str
             return;
         }
 
-        const value = params[inputName];
+        const value = withContractDefault(params[inputName], config.default);
         if (value === undefined) {
             return;
         }

--- a/packages/core/tests/local-api-contracts.test.ts
+++ b/packages/core/tests/local-api-contracts.test.ts
@@ -328,6 +328,15 @@ describe('shared contract metadata and serializers', () => {
         });
     });
 
+    it('serializes get-browser-list with CLI pagination defaults when omitted', () => {
+        const parsed = schemas.getBrowserListSchema.parse({});
+
+        expect(buildRequestBodyFor('get-browser-list', parsed)).toEqual({
+            limit: 200,
+            page: 1,
+        });
+    });
+
     it('serializes create-browser body with platform_account', () => {
         const parsed = schemas.createBrowserSchema.parse({
             group_id: '0',

--- a/skills/adspower-browser/SKILL.md
+++ b/skills/adspower-browser/SKILL.md
@@ -104,7 +104,7 @@ ads close-browser <profile_id>                   # Or JSON: profile_id? | profil
 ### Browser profile – create/update/delete/list
 
 ```bash
-ads create-browser '{"group_id":"0","user_proxy_config":{"proxy_soft":"no_proxy"},...}'  # group_id + account field required; proxy optional (defaults to no_proxy; proxyid takes priority over user_proxy_config when both given)
+ads create-browser '{"group_id":"0","user_proxy_config":{"proxy_soft":"no_proxy"},...}'  # group_id required: always include it; use "0" for Ungrouped; if given a group name, call get-group-list first; include either proxyid or user_proxy_config
 ads update-browser '{"profile_id":"...",...}'    # profile_id required
 ads delete-browser '{"profile_id":["..."]}'     # profile_id required
 ads get-browser-list '{}'                       # Or group_id?, limit?, page?, profile_id[]?, profile_no[]?, sort_type?, sort_order?, tag_ids?, tags_filter?, name?, name_filter?
@@ -203,7 +203,7 @@ See [references/client-patch-management.md](references/client-patch-management.m
 
 ### user_proxy_config (inline proxy config for create-browser / update-browser)
 
-See [references/user-proxy-config.md](references/user-proxy-config.md) for all fields (proxy_soft, proxy_type, proxy_host, proxy_port, etc.) and example. Defaults to `{"proxy_soft":"no_proxy"}` when omitted. If **proxyid** is also provided, **proxyid** takes priority and **user_proxy_config** is ignored.
+See [references/user-proxy-config.md](references/user-proxy-config.md) for all fields (proxy_soft, proxy_type, proxy_host, proxy_port, etc.) and example. For **create-browser**, include either **proxyid** or **user_proxy_config**. If the user does not specify a proxy when creating a browser profile, set **user_proxy_config** to `{"proxy_soft":"no_proxy"}`. For **update-browser**, include **proxyid** or **user_proxy_config** only when changing the profile proxy.
 
 ### fingerprint_config (fingerprint config for create-browser / update-browser)
 

--- a/skills/adspower-browser/SKILL.md
+++ b/skills/adspower-browser/SKILL.md
@@ -107,9 +107,11 @@ ads close-browser <profile_id>                   # Or JSON: profile_id? | profil
 ads create-browser '{"group_id":"0","user_proxy_config":{"proxy_soft":"no_proxy"},...}'  # group_id required: always include it; use "0" for Ungrouped; if given a group name, call get-group-list first; include either proxyid or user_proxy_config
 ads update-browser '{"profile_id":"...",...}'    # profile_id required
 ads delete-browser '{"profile_id":["..."]}'     # profile_id required
-ads get-browser-list '{}'                       # Or group_id?, limit?, page?, profile_id[]?, profile_no[]?, sort_type?, sort_order?, tag_ids?, tags_filter?, name?, name_filter?
+ads get-browser-list '{}'                       # CLI defaults to page=1,limit=200 (Local API itself returns only 1). Or group_id?, limit?, page?, profile_id[]?, profile_no[]?, sort_type?, sort_order?, tag_ids?, tags_filter?, name?, name_filter?
 ads get-opened-browser                          # No params
 ```
+
+**Listing all environments:** `get-browser-list` returns `total_count` / `total_pages`. The CLI sends `page=1,limit=200` by default, so one call covers up to 200 profiles. If `total_pages > 1`, keep calling with the same filters and `page + 1` until every page is collected. For "operate on all environments in a group" tasks, gather all pages first, then act on every returned `profile_id` — never just the first.
 
 ### Browser profile – move/cookies/UA/fingerprint/cache/share/active
 

--- a/skills/adspower-browser/references/browser-profile-management.md
+++ b/skills/adspower-browser/references/browser-profile-management.md
@@ -24,7 +24,7 @@
 
 - **group_id** (required): Numeric string; use `"0"` for Ungrouped. Get list via get-group-list.
 - At least one of **username**, **password**, **cookie**, **fakey** (required): Account information.
-- **user_proxy_config** (required when **proxyid** is not provided; default `{"proxy_soft":"no_proxy"}`): Inline proxy config (see [user-proxy-config.md](user-proxy-config.md)). When **proxyid** is present, this field is ignored.
+- **user_proxy_config** (required when **proxyid** is not provided): Inline proxy config (see [user-proxy-config.md](user-proxy-config.md)). For **create-browser**, if the user does not specify a proxy, set this field to `{"proxy_soft":"no_proxy"}`. When **proxyid** is present, this field is ignored.
 - **proxyid** (optional): Saved proxy ID or `"random"`. Takes priority over **user_proxy_config**; when provided, **user_proxy_config** may be omitted.
 - **name** (optional, max 100): Account name.
 - **platform** (optional): Platform domain, e.g. facebook.com.

--- a/skills/adspower-browser/references/browser-profile-management.md
+++ b/skills/adspower-browser/references/browser-profile-management.md
@@ -55,8 +55,8 @@
 **get-browser-list** — Get the list of browsers.
 
 - **group_id** (optional): Numeric string; query by group ID; empty searches all groups.
-- **limit** (optional): 1–200, default 50. Profiles per page.
-- **page** (optional): Default 1.
+- **limit** (optional): 1–200. Profiles per page. The Local API defaults to only **1** when omitted, so the CLI injects `limit=200` for you; pass an explicit value to override.
+- **page** (optional): Page number. The CLI injects `page=1` when omitted.
 - **profile_id** (optional): Array, e.g. `["h1yynkm","h1yynks"]`.
 - **profile_no** (optional): Array, e.g. `["123","124"]`.
 - **sort_type** (optional): `'profile_no'` | `'last_open_time'` | `'created_time'`.
@@ -66,6 +66,13 @@
 - **tags_filter** (optional): `'include'` (default) | `'exclude'` for tag match mode.
 - **name** (optional): Environment name keyword.
 - **name_filter** (optional): `'include'` (default) | `'exclude'` for name match mode.
+
+Pagination & bulk operations:
+
+- The response includes `page`, `page_size`, `total_count`, and `total_pages`. Use them to tell whether you have the full set.
+- The CLI already defaults to `page=1, limit=200`, so a single call returns up to 200 profiles. Do not assume the first profile is the whole result unless the user asked for one.
+- If `total_pages > 1` (more than 200 matches), request the next page with the same filters and `page + 1`, repeating until you have collected every page.
+- For "operate on all environments in a group / matching a filter" tasks, collect all pages first, then iterate over every returned `profile_id`.
 
 **get-opened-browser** — Get the list of opened browsers.
 

--- a/skills/adspower-browser/references/user-proxy-config.md
+++ b/skills/adspower-browser/references/user-proxy-config.md
@@ -1,6 +1,6 @@
 # user_proxy_config (inline proxy config for create-browser / update-browser)
 
-Used to configure an inline proxy for **create-browser** / **update-browser**. Defaults to `{"proxy_soft":"no_proxy"}` when omitted. If **proxyid** is also provided, **proxyid** takes priority and this config is ignored. Field names match the API (snake_case):
+Used to configure an inline proxy for **create-browser** / **update-browser**. For **create-browser**, include either **proxyid** or **user_proxy_config**. If the user does not specify a proxy when creating a browser profile, set **user_proxy_config** to `{"proxy_soft":"no_proxy"}`. For **update-browser**, include this config only when changing the profile proxy. If **proxyid** is also provided, **proxyid** takes priority and this config is ignored. Field names match the API (snake_case):
 
 - **proxy_soft** (required): Proxy software type. `'brightdata'` | `'brightauto'` | `'oxylabsauto'` | `'922S5auto'` | `'ipfoxyauto'` | `'922S5auth'` | `'kookauto'` | `'ssh'` | `'other'` | `'no_proxy'`
 - **proxy_type** (optional): Proxy type. `'http'` | `'https'` | `'socks5'` | `'no_proxy'`


### PR DESCRIPTION
## 背景

AdsPower Local API 的 `get-browser-list` 在省略 `limit` 时默认只返回 1 条环境记录，容易导致“查询全部环境”或“对分组内全部环境执行操作”的场景只处理到第一条结果。

同时，创建/更新浏览器环境时 `proxyid` 和 `user_proxy_config` 的使用规则需要在 skill 文档里表达得更明确，避免创建环境时漏传代理配置或更新环境时误改代理。

## 变更内容

- 为 Local API 契约参数增加 `default` 支持。
- `get-browser-list` 在 CLI 请求构造阶段默认补齐 `page=1`、`limit=200`。
- 请求构造器只在参数为 `undefined` 时应用契约默认值，保留调用方显式传入的 `null`。
- 更新 `get-browser-list` 的 schema 描述，说明 CLI 默认分页和 Local API 原始默认行为差异。
- 补充契约测试，覆盖省略分页参数时的默认请求体。
- 同步更新 CLI README、skill 快捷说明和浏览器环境管理参考文档。
- 明确创建浏览器环境时应提供 `proxyid` 或 `user_proxy_config`，未指定代理时使用 `{"proxy_soft":"no_proxy"}`。
- 补充分页说明：批量操作前应根据 `total_pages` 收集完整结果，不能只处理第一页或第一条环境。

## 验证

- `git diff --check`
- `pnpm run typecheck`
- `pnpm exec vitest run --config vitest.config.ts packages/core/tests/local-api-contracts.test.ts -t "get-browser-list|update-group"`

说明：完整 `test:contracts` 当前仍存在既有失败项，集中在 `get-group-list` handler 返回格式/错误包装断言，以及 `open-browser` headless note 断言；本 PR 相关用例已通过。